### PR TITLE
support for options.data as object to add query string parameters

### DIFF
--- a/src/storages/fetch.js
+++ b/src/storages/fetch.js
@@ -60,6 +60,16 @@ fetchStorage.sync = function (method, model, options) {
         url = base + url;
     }
 
+    if (options.data) {
+        var params = [];
+        for (key in options.data) {
+            params.push(key + '=' + encodeURIComponent(options.data[key]));
+        }
+        if (params.length) {
+            url = url + '?' + params.join('&');
+        }
+    }
+
     fetchStorage.send(url, request, function (error, json) {
         console.log(error, json, options);
         if (error) {


### PR DESCRIPTION
Support for options.data as object to add query string parameters: url?key1=value1&key2=value2 

Examples
Fetch a specific page of collection: Documents.fetch({data: {page: 3}})
Send a keyword on a serch endpoint: Search.fetch({data: {keywords: 'foo bar'}})